### PR TITLE
Maintenance/WS link table: Remove surrogate key

### DIFF
--- a/datamodel/re_maintenance_event_wastewater_structure.sql
+++ b/datamodel/re_maintenance_event_wastewater_structure.sql
@@ -1,18 +1,12 @@
 -------
 CREATE TABLE qgep.re_maintenance_event_wastewater_structure
 (
-   obj_id  varchar(16) NOT NULL,
-   CONSTRAINT pkey_qgep_re_maintenance_event_wastewater_structure_obj_id PRIMARY KEY (obj_id)
+  fk_wastewater_structure varchar (16),
+  fk_maintenance_event varchar (16),
+  CONSTRAINT rel_maintenance_event_wastewater_structure_wastewater_structure FOREIGN KEY (fk_wastewater_structure) REFERENCES qgep.od_wastewater_structure(obj_id),
+  CONSTRAINT rel_maintenance_event_wastewater_structure_maintenance_event FOREIGN KEY (fk_maintenance_event) REFERENCES qgep.od_maintenance_event(obj_id),
+  CONSTRAINT pkey_qgep_re_maintenance_event_wastewater_structure_obj_id PRIMARY KEY (fk_wastewater_structure, fk_maintenance_event)
 )
 WITH (
    OIDS = False
 );
-CREATE SEQUENCE qgep.seq_re_maintenance_event_wastewater_structure_oid INCREMENT 1 MINVALUE 0 MAXVALUE 999999 START 0;
- ALTER TABLE qgep.re_maintenance_event_wastewater_structure ALTER COLUMN obj_id SET DEFAULT qgep.generate_oid('re_maintenance_event_wastewater_structure');
-COMMENT ON COLUMN qgep.re_maintenance_event_wastewater_structure.obj_id IS 'INTERLIS STANDARD OID (with Postfix/Präfix) or UUOID, see www.interlis.ch';
-
--------- Relationships ----------
-ALTER TABLE qgep.re_maintenance_event_wastewater_structure ADD COLUMN fk_wastewater_structure varchar (16);
-ALTER TABLE qgep.re_maintenance_event_wastewater_structure ADD CONSTRAINT rel_maintenance_event_wastewater_structure_wastewater_structure FOREIGN KEY (fk_wastewater_structure) REFERENCES qgep.od_wastewater_structure(obj_id);
-ALTER TABLE qgep.re_maintenance_event_wastewater_structure ADD COLUMN fk_maintenance_event varchar (16);
-ALTER TABLE qgep.re_maintenance_event_wastewater_structure ADD CONSTRAINT rel_maintenance_event_wastewater_structure_maintenance_event FOREIGN KEY (fk_maintenance_event) REFERENCES qgep.od_maintenance_event(obj_id);


### PR DESCRIPTION
Proposal to stick to database "standards" for link tables.
Instead of a surrogate primary key a compound key could be used.

See http://stackoverflow.com/a/2190294/2319028

References #113