### PR TITLE
Sets smaller values for labeling engine position trials

### DIFF
--- a/project/qgep_en.qgs
+++ b/project/qgep_en.qgs
@@ -14674,6 +14674,18 @@ def my_form_open(dialog, layer, feature):
     <WMSRootName type="QString"></WMSRootName>
     <WMSServiceTitle type="QString"></WMSServiceTitle>
     <WMSContactPhone type="QString"></WMSContactPhone>
+    <PAL>
+      <SearchMethod type="int">0</SearchMethod>
+      <ShowingShadowRects type="bool">false</ShowingShadowRects>
+      <CandidatesPolygon type="int">10</CandidatesPolygon>
+      <ShowingCandidates type="bool">false</ShowingCandidates>
+      <DrawRectOnly type="bool">false</DrawRectOnly>
+      <ShowingPartialsLabels type="bool">true</ShowingPartialsLabels>
+      <CandidatesLine type="int">10</CandidatesLine>
+      <CandidatesPoint type="int">13</CandidatesPoint>
+      <ShowingAllLabels type="bool">false</ShowingAllLabels>
+      <DrawOutlineLabels type="bool">true</DrawOutlineLabels>
+    </PAL>
     <WFSTLayers>
       <Insert type="QStringList"/>
       <Update type="QStringList"/>


### PR DESCRIPTION
Default labeling engine settings where making QGIS compute too much potential positions. 
related to https://github.com/QGEP/QGEP/issues/308#issuecomment-324385868