### PR TITLE
Create 23_main_node.sql

### DIFF
--- a/migration/23_main_node.sql
+++ b/migration/23_main_node.sql
@@ -1,0 +1,10 @@
+UPDATE qgep_od.wastewater_structure WS
+SET fk_main_wastewater_node = structure_node.wn_obj_id
+FROM (
+  SELECT WS.obj_id AS obj_id, min(WN.obj_id) AS wn_obj_id
+  FROM qgep_od.wastewater_structure WS
+  LEFT JOIN qgep_od.wastewater_networkelement NE ON NE.fk_wastewater_structure = WS.obj_id
+  LEFT JOIN qgep_od.wastewater_node WN ON NE.obj_id = WN.obj_id
+  GROUP BY WS.obj_id
+) AS structure_node
+WHERE structure_node.obj_id = WS.obj_id;


### PR DESCRIPTION
With datamodel 1.4.0, when importing records the main node has to be defined.  Analogous to 22_main_cover