### PR TITLE
remove autocrlf from gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,3 @@
-# Auto detect text files and perform LF normalization
-* text=auto
-
 # Custom for Visual Studio
 *.cs     diff=csharp
 *.sln    merge=union


### PR DESCRIPTION
Can we remove this ? It's seems not possible to override .gitattribute locally and this is overriding my autocrlf setup (changing all line endings on windows).

If we want to ensure we have consistent line endings in the repo, let's put some automated checks instead